### PR TITLE
Allow the idle_timeout parameter to be configured.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,4 @@ If you absolutly must, use the non-buffered plugin (we really recommend using th
 * **endpoint_url** the url to Logz.io input where `xxx-xxxx...` is your Logz.io access token, and `my_type` is the type of your logs in logz.io
 * **output_include_time** should the appender add a timestamp to your logs on their process time. (recommended)
 * **output_include_tags** should the appender add the fluentd tag to the document, called "fluentd_tag"
+* **http_idle_timeout** timeout in seconds that the http persistent connection will stay open without traffic

--- a/lib/fluent/plugin/out_logzio_buffered.rb
+++ b/lib/fluent/plugin/out_logzio_buffered.rb
@@ -5,6 +5,7 @@ module Fluent
     config_param :output_include_time, :bool, default: true
     config_param :output_include_tags, :bool, default: true
     config_param :retry_count, :integer, default: 3 # How many times to resend failed bulks. Undocumented because not suppose to be changed
+    config_param :http_idle_timeout, :integer, default: 5
 
     unless method_defined?(:log)
       define_method('log') { $log }
@@ -21,6 +22,8 @@ module Fluent
       @uri = URI @endpoint_url
       @http = Net::HTTP::Persistent.new 'fluent-plugin-logzio', :ENV
       @http.headers['Content-Type'] = 'text/plain'
+      @http.idle_timeout = @http_idle_timeout
+      @http.socket_options << [Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, 1]
       $log.debug "Started logzio shipper.."
     end
 


### PR DESCRIPTION
New config parameter to set the Net:Http:Persistent.idle_timeout parameter.
Also sets TCP_KEEPALIVE on for the http socket since it helps for persistent connections.
