### PR TITLE
Allowing the attached tags to have a custom fieldname

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ With fluent-plugin-logzio you will be able to use [Logz.io](http://logz.io) as o
       endpoint_url https://listener.logz.io:8071?token=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&type=my_type
       output_include_time true
       output_include_tags true
+      output_tags_fieldname @log_name
       buffer_type    file
       buffer_path    /path/to/buffer/file
       flush_interval 10s
@@ -34,5 +35,6 @@ If you absolutly must, use the non-buffered plugin (we really recommend using th
 ## Parameters
 * **endpoint_url** the url to Logz.io input where `xxx-xxxx...` is your Logz.io access token, and `my_type` is the type of your logs in logz.io
 * **output_include_time** should the appender add a timestamp to your logs on their process time. (recommended)
-* **output_include_tags** should the appender add the fluentd tag to the document, called "fluentd_tag"
+* **output_include_tags** should the appender add the fluentd tag to the document, called "fluentd_tag" (which can be renamed, see next point)
+* **output_tags_fieldname** set the tag's fieldname, defaults to "fluentd_tag"
 * **http_idle_timeout** timeout in seconds that the http persistent connection will stay open without traffic

--- a/lib/fluent/plugin/out_logzio_buffered.rb
+++ b/lib/fluent/plugin/out_logzio_buffered.rb
@@ -6,6 +6,7 @@ module Fluent
     config_param :output_include_tags, :bool, default: true
     config_param :retry_count, :integer, default: 3 # How many times to resend failed bulks. Undocumented because not suppose to be changed
     config_param :http_idle_timeout, :integer, default: 5
+    config_param :output_tags_fieldname, :string, default: 'fluentd_tags'
 
     unless method_defined?(:log)
       define_method('log') { $log }
@@ -40,7 +41,7 @@ module Fluent
 
       chunk.msgpack_each {|tag,time,record|
         record['@timestamp'] ||= Time.at(time).iso8601(3) if @output_include_time
-        record['fluentd_tags'] ||= tag.to_s if @output_include_tags
+        record[@output_tags_fieldname] ||= tag.to_s if @output_include_tags
         records.push(Yajl.dump(record))
       }
 


### PR DESCRIPTION
So, turns out #6 wasn't particularly complex to implement.

Allows the `fluentd_tags` property to have a different name. In AWS ES, the logstash / fluentd tags can be found under the property `@log_name`, so in migrating from AWS ES to Logz.io being able to set the property for the fluent tag means migrating all visualisations is easy & querying seems more familiar 😄 