### PR TITLE
Fix buffered plugin spec

### DIFF
--- a/spec/lib/fluent/plugin/out_logzio_buffered_spec.rb
+++ b/spec/lib/fluent/plugin/out_logzio_buffered_spec.rb
@@ -14,7 +14,7 @@ describe 'Fluent::LogzioOutputBuffered' do
 
   describe 'emit' do
     before(:each) do
-      expect(request).to receive(:body=).with('{"field1":50,"otherfield":99}\n{"field1":150,"otherfield":199}')
+      expect(request).to receive(:body=).with('{"field1":50,"otherfield":99,"fluentd_tags":"test"}' + "\n" + '{"field1":150,"otherfield":199,"fluentd_tags":"test"}')
       expect(Net::HTTP::Post).to receive(:new).with('/?token=123').once.and_return(request)
       expect_any_instance_of(Net::HTTP::Persistent).to receive(:request).once.and_return(response)
     end


### PR DESCRIPTION
Use a double-quoted string for the newline in the expected response
since single-quoted strings don't convert \n to a newline.
Expect `fluentd_tags` field to exist since the plugin outputs it by
default.