### PR TITLE
Ignore records that fail to serialize in the buffered output

### DIFF
--- a/lib/fluent/plugin/out_logzio_buffered.rb
+++ b/lib/fluent/plugin/out_logzio_buffered.rb
@@ -40,9 +40,13 @@ module Fluent
       records = []
 
       chunk.msgpack_each {|tag,time,record|
-        record['@timestamp'] ||= Time.at(time).iso8601(3) if @output_include_time
-        record[@output_tags_fieldname] ||= tag.to_s if @output_include_tags
-        records.push(Yajl.dump(record))
+        begin
+          record['@timestamp'] ||= Time.at(time).iso8601(3) if @output_include_time
+          record[@output_tags_fieldname] ||= tag.to_s if @output_include_tags
+          records.push(Yajl.dump(record))
+        rescue
+          log.error("Adding record #{record} to buffer failed. Exception: #{$!}")
+        end
       }
 
       log.debug "Got flush timeout, containing #{records.length} chunks"


### PR DESCRIPTION
Yajl.dump cannot handle records with NaN values in them; however, a
large number of tools produce such records (including, AFAICT, the
fluentd node logger). This change handles the exception and ignores the
message.

If the message is not ignored, basically everything breaks. Fluentd
keeps trying to resend the buffer that contains the message, always
failing because the message hasn't changed and still cannot be
serialized; an ever increasing number of buffer files are created, and,
eventually, the size limit is reached and fluent starts dropping data.
TL;DR currently the buffered plugin has no way of dealing with non-transient
errors beyond manually deleting the offending buffer files which is
far from ideal.