### PR TITLE
Adopt more v1 style

### DIFF
--- a/lib/fluent/plugin/out_logzio_buffered.rb
+++ b/lib/fluent/plugin/out_logzio_buffered.rb
@@ -45,7 +45,7 @@ module Fluent
 
     def format(tag, time, record)
       if time.is_a?(Fluent::EventTime)
-        sec_frac = time.sec + time.nsec / 10.0 ** 9
+        sec_frac = time.to_f
       else
         sec_frac = time * 1.0
       end

--- a/lib/fluent/plugin/out_logzio_buffered.rb
+++ b/lib/fluent/plugin/out_logzio_buffered.rb
@@ -16,15 +16,11 @@ module Fluent
     config_param :http_idle_timeout, :integer, default: 5
     config_param :output_tags_fieldname, :string, default: 'fluentd_tags'
 
-    unless method_defined?(:log)
-      define_method('log') { $log }
-    end
-
     def configure(conf)
       super
       compat_parameters_convert(conf, :buffer)
 
-      $log.debug "Logz.io URL #{@endpoint_url}"
+      log.debug "Logz.io URL #{@endpoint_url}"
     end
 
     def start


### PR DESCRIPTION
* `plugin#log` always exists in Fluentd v1.
* `Fluent::EventTime#to_f` generate float point time value.