### PR TITLE
Adds Proxy

### DIFF
--- a/lib/fluent/plugin/out_logzio_buffered.rb
+++ b/lib/fluent/plugin/out_logzio_buffered.rb
@@ -23,11 +23,17 @@ module Fluent
       compat_parameters_convert(conf, :buffer)
 
       log.debug "Logz.io URL #{@endpoint_url}"
-      log.debug "Proxy #{@proxy_uri}"
-      log.debug "Proxy #{@proxy_cert}"
+
+      if params[:proxy_uri].present?
+        log.debug "Proxy #{@proxy_uri}"
+        ENV['http_proxy'] = @proxy_uri
+      end
+    
+      if params[:proxy_cert].present?
+        log.debug "Proxy #{@proxy_cert}"
+        ENV['SSL_CERT_FILE'] = @proxy_cert
+      end
       
-      ENV['http_proxy'] = @proxy_uri
-      ENV['SSL_CERT_FILE'] = @proxy_cert
     end
 
     def start

--- a/lib/fluent/plugin/out_logzio_buffered.rb
+++ b/lib/fluent/plugin/out_logzio_buffered.rb
@@ -24,12 +24,12 @@ module Fluent
 
       log.debug "Logz.io URL #{@endpoint_url}"
 
-      if params[:proxy_uri].present?
+      if conf['proxy_uri']
         log.debug "Proxy #{@proxy_uri}"
         ENV['http_proxy'] = @proxy_uri
       end
     
-      if params[:proxy_cert].present?
+      if conf['proxy_cert']
         log.debug "Proxy #{@proxy_cert}"
         ENV['SSL_CERT_FILE'] = @proxy_cert
       end

--- a/lib/fluent/plugin/out_logzio_buffered.rb
+++ b/lib/fluent/plugin/out_logzio_buffered.rb
@@ -15,12 +15,16 @@ module Fluent
     config_param :bulk_limit, :integer, default: 1000000 # Make sure submission to LogzIO does not exceed 1MB limit and leave some overhead
     config_param :http_idle_timeout, :integer, default: 5
     config_param :output_tags_fieldname, :string, default: 'fluentd_tags'
+    config_param :proxy_uri, :string, default: nil
 
     def configure(conf)
       super
       compat_parameters_convert(conf, :buffer)
 
       log.debug "Logz.io URL #{@endpoint_url}"
+      log.debug "Proxy #{@proxy_uri}"
+      
+      ENV['http_proxy'] = @proxy_uri
     end
 
     def start

--- a/lib/fluent/plugin/out_logzio_buffered.rb
+++ b/lib/fluent/plugin/out_logzio_buffered.rb
@@ -16,6 +16,7 @@ module Fluent
     config_param :http_idle_timeout, :integer, default: 5
     config_param :output_tags_fieldname, :string, default: 'fluentd_tags'
     config_param :proxy_uri, :string, default: nil
+    config_param :proxy_cert, :string, default: nil
 
     def configure(conf)
       super
@@ -23,8 +24,10 @@ module Fluent
 
       log.debug "Logz.io URL #{@endpoint_url}"
       log.debug "Proxy #{@proxy_uri}"
+      log.debug "Proxy #{@proxy_cert}"
       
       ENV['http_proxy'] = @proxy_uri
+      ENV['SSL_CERT_FILE'] = @proxy_cert
     end
 
     def start


### PR DESCRIPTION
If proxy_uri and proxy_cert are defined in your fluentd config file they are set as env vars for ruby to use when making the HTTPS connection.