### PR TITLE
Tweak for v1

### DIFF
--- a/lib/fluent/plugin/out_logzio_buffered.rb
+++ b/lib/fluent/plugin/out_logzio_buffered.rb
@@ -1,7 +1,7 @@
 require 'time'
 require 'fluent/plugin/output'
 
-module Fluent
+module Fluent::Plugin
   class LogzioOutputBuffered < Output
     Fluent::Plugin.register_output('logzio_buffered', self)
 

--- a/lib/fluent/plugin/out_logzio_buffered.rb
+++ b/lib/fluent/plugin/out_logzio_buffered.rb
@@ -44,6 +44,10 @@ module Fluent::Plugin
       true
     end
 
+    def multi_workers_ready?
+      true
+    end
+
     def format(tag, time, record)
       if time.is_a?(Fluent::EventTime)
         sec_frac = time.to_f

--- a/spec/lib/fluent/plugin/out_logzio_buffered_spec.rb
+++ b/spec/lib/fluent/plugin/out_logzio_buffered_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe 'Fluent::LogzioOutputBuffered' do
-  let(:driver) { Fluent::Test::Driver::Output.new(Fluent::LogzioOutputBuffered).configure(config) }
+describe 'Fluent::Plugin::LogzioOutputBuffered' do
+  let(:driver) { Fluent::Test::Driver::Output.new(Fluent::Plugin::LogzioOutputBuffered).configure(config) }
   let(:config) do
     %[
       endpoint_url         https://logz.io?token=123

--- a/spec/lib/fluent/plugin/out_logzio_multi_bulk_spec.rb
+++ b/spec/lib/fluent/plugin/out_logzio_multi_bulk_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe 'Fluent::LogzioOutputBuffered' do
-  let(:driver) { Fluent::Test::Driver::Output.new(Fluent::LogzioOutputBuffered).configure(config) }
+describe 'Fluent::Plugin::LogzioOutputBuffered' do
+  let(:driver) { Fluent::Test::Driver::Output.new(Fluent::Plugin::LogzioOutputBuffered).configure(config) }
   let(:config) do
     %[
       endpoint_url         https://logz.io?token=123

--- a/spec/lib/fluent/plugin/out_logzio_record_too_large_spec.rb
+++ b/spec/lib/fluent/plugin/out_logzio_record_too_large_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe 'Fluent::LogzioOutputBuffered' do
-  let(:driver) { Fluent::Test::Driver::Output.new(Fluent::LogzioOutputBuffered).configure(config) }
+describe 'Fluent::Plugin::LogzioOutputBuffered' do
+  let(:driver) { Fluent::Test::Driver::Output.new(Fluent::Plugin::LogzioOutputBuffered).configure(config) }
   let(:config) do
     %[
       endpoint_url         https://logz.io?token=123


### PR DESCRIPTION
Put logzio output plugin class under `Fluent::Plugin` module and thus, it inherits `Fluent::Plugin::Output` class which is really assumed to be used in Fluentd v1.
Permit to work multi workers with `#multi_workers_ready?` implementation.