### PR TITLE
Handle 4xx response, add metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ This is an **example** only. Your needs in production may vary!
 
 
 ## Release Notes
+- **0.1.1**:
+  - Prevent retry upon `400` and `401` from Logz.io.
 - **0.1.0**:
   - Use fluentd's retry instead of retry in code (raise exception on non-2xx response).
 - 0.0.22: Update gem `net-http-persistent` to 4.x.

--- a/README.md
+++ b/README.md
@@ -70,13 +70,22 @@ This is an **example** only. Your needs in production may vary!
 * **bulk_limit** Limit to the size of the Logz.io upload bulk. Defaults to 1000000 bytes leaving about 24kB for overhead.
 * **bulk_limit_warning_limit** Limit to the size of the Logz.io warning message when a record exceeds bulk_limit to prevent a recursion when Fluent warnings are sent to the Logz.io output.  Defaults to nil (no truncation).
 * **proxy_uri** Your proxy uri. Default is nil. For example: "`my.ip:12345`".
-* **proxy_cert** Your proxy cert. Default is nil
-* **gzip** should the plugin ship the logs in gzip compression. Default is false
+* **proxy_cert** Your proxy cert. Default is nil.
+* **gzip** should the plugin ship the logs in gzip compression. Default is false.
+* **error_on_4xx** should the plugin raise an exception (and thus use fluentd's retry) upon 4xx respons from logz.io. Default is false.
+
+
+## Plugin metrics:
+
+| Metric Name | Description | Type | Example |
+| --- | --- | --- | --- |
+| `logzio_status_codes` | Status codes received from Logz.io | Gauge | `logzio_status_codes{type="logzio_buffered",plugin_id="out_logzio",status_code="500"}` |
 
 
 ## Release Notes
-- **0.1.1**:
-  - Prevent retry upon `400` and `401` from Logz.io.
+- **0.2.0**:
+  - Add `error_on_4xx` (defaults to `false`) to determine wheter to raise an exception upon 4xx response from logz.io.
+  - Generate a metric (`logzio_status_codes`) for response codes from Logz.io.
 - **0.1.0**:
   - Use fluentd's retry instead of retry in code (raise exception on non-2xx response).
 - 0.0.22: Update gem `net-http-persistent` to 4.x.

--- a/fluent-plugin-logzio.gemspec
+++ b/fluent-plugin-logzio.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = 'fluent-plugin-logzio'
-  s.version     = '0.1.1'
+  s.version     = '0.2.0'
   s.authors     = ['Yury Kotov', 'Roi Rav-Hon', 'Arcadiy Ivanov', 'Miri Bar']
   s.email       = ['bairkan@gmail.com', 'roi@logz.io', 'arcadiy@ivanov.biz', 'miri.ignatiev@logz.io']
   s.homepage    = 'https://github.com/logzio/fluent-plugin-logzio'
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'net-http-persistent', '~> 4.0'
   s.add_runtime_dependency 'fluentd', ['>= 0.14.0', '< 2']
+  s.add_runtime_dependency 'prometheus-client', '>= 2.1.0'
   s.add_development_dependency 'rake', '~> 12.3'
   s.add_development_dependency 'bundler', '~> 1.16'
   s.add_development_dependency 'rspec', '~> 3.7'

--- a/fluent-plugin-logzio.gemspec
+++ b/fluent-plugin-logzio.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = 'fluent-plugin-logzio'
-  s.version     = '0.1.0'
+  s.version     = '0.1.1'
   s.authors     = ['Yury Kotov', 'Roi Rav-Hon', 'Arcadiy Ivanov', 'Miri Bar']
   s.email       = ['bairkan@gmail.com', 'roi@logz.io', 'arcadiy@ivanov.biz', 'miri.ignatiev@logz.io']
   s.homepage    = 'https://github.com/logzio/fluent-plugin-logzio'

--- a/lib/fluent/plugin/out_logzio_buffered.rb
+++ b/lib/fluent/plugin/out_logzio_buffered.rb
@@ -139,9 +139,9 @@ module Fluent::Plugin
       end
 
       if not response.code.start_with?('2')
-        if response.code == 400
+        if response.code == '400'
           log.error "Received #{response.code} from Logzio. Some logs may be malformed or too long. Valid logs were succesfully sent into the system. Will not retry sending. Response body: #{response.body}"
-        elsif response.code == 401
+        elsif response.code == '401'
           log.error "Received #{response.code} from Logzio. Unauthorized, please check your logs shipping token. Will not retry sending. Response body: #{response.body}"
         else
           log.debug "Failed request body: #{post.body}"


### PR DESCRIPTION
In this PR:
* Update readme.
* Add new config field - `error_on_4xx` (default - false), which determines if the plugin will raise an exception on 4xx response from logz.io. If true, the plugin will raise an error on 4xx response, and fluentd will retry to send it (which will also update fluentd's errors + retry metrics). If false - will not raise an error and will not retry.
* Add new metric - `logzio_status_codes` - the http status codes from logz.io.
For example:
```
logzio_status_codes{type="logzio_buffered",plugin_id="out_logzio",status_code="500"} 3.0
logzio_status_codes{type="logzio_buffered",plugin_id="out_logzio",status_code="200"} 1.0
```