### PR TITLE
Retry fix without drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ This is an **example** only. Your needs in production may vary!
 
 
 ## Release Notes
+- **0.1.1**:
+  - Prevent retry upon `400` and `401` from Logz.io.
 - **0.1.0**:
   - Use fluentd's retry instead of retry in code (raise exception on non-2xx response).
 - 0.0.22: Update gem `net-http-persistent` to 4.x.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ This is an **example** only. Your needs in production may vary!
 * **proxy_uri** Your proxy uri. Default is nil. For example: "`my.ip:12345`".
 * **proxy_cert** Your proxy cert. Default is nil.
 * **gzip** should the plugin ship the logs in gzip compression. Default is false.
-* **error_on_4xx** should the plugin raise an exception (and thus use fluentd's retry) upon 4xx respons from logz.io. Default is false.
 
 
 ## Plugin metrics:
@@ -84,7 +83,7 @@ This is an **example** only. Your needs in production may vary!
 
 ## Release Notes
 - **0.2.0**:
-  - Add `error_on_4xx` (defaults to `false`) to determine wheter to raise an exception upon 4xx response from logz.io.
+  - Do not retry on 400 and 401. For 400 - try to fix log and resend.
   - Generate a metric (`logzio_status_codes`) for response codes from Logz.io.
 - **0.1.0**:
   - Use fluentd's retry instead of retry in code (raise exception on non-2xx response).

--- a/README.md
+++ b/README.md
@@ -70,13 +70,22 @@ This is an **example** only. Your needs in production may vary!
 * **bulk_limit** Limit to the size of the Logz.io upload bulk. Defaults to 1000000 bytes leaving about 24kB for overhead.
 * **bulk_limit_warning_limit** Limit to the size of the Logz.io warning message when a record exceeds bulk_limit to prevent a recursion when Fluent warnings are sent to the Logz.io output.  Defaults to nil (no truncation).
 * **proxy_uri** Your proxy uri. Default is nil. For example: "`my.ip:12345`".
-* **proxy_cert** Your proxy cert. Default is nil
-* **gzip** should the plugin ship the logs in gzip compression. Default is false
+* **proxy_cert** Your proxy cert. Default is nil.
+* **gzip** should the plugin ship the logs in gzip compression. Default is false.
+* **error_on_4xx** should the plugin raise an exception (and thus use fluentd's retry) upon 4xx respons from logz.io. Default is false.
+
+
+## Plugin metrics:
+
+| Metric Name | Description | Type | Example |
+| --- | --- | --- | --- |
+| `logzio_status_codes` | Status codes received from Logz.io | Gauge | `logzio_status_codes{type="logzio_buffered",plugin_id="out_logzio",status_code="500"}` |
 
 
 ## Release Notes
-- **0.1.1**:
-  - Prevent retry upon `400` and `401` from Logz.io.
+- **0.2.0**:
+  - Add `error_on_4xx` (defaults to `false`) to determine wheter to raise an exception upon 4xx response from logz.io.
+  - Generate a metric (`logzio_status_codes`) for response codes from Logz.io.
 - **0.1.0**:
   - Use fluentd's retry instead of retry in code (raise exception on non-2xx response).
 - 0.0.22: Update gem `net-http-persistent` to 4.x.

--- a/fluent-plugin-logzio.gemspec
+++ b/fluent-plugin-logzio.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = 'fluent-plugin-logzio'
-  s.version     = '0.1.1'
+  s.version     = '0.2.0'
   s.authors     = ['Yury Kotov', 'Roi Rav-Hon', 'Arcadiy Ivanov', 'Miri Bar']
   s.email       = ['bairkan@gmail.com', 'roi@logz.io', 'arcadiy@ivanov.biz', 'miri.ignatiev@logz.io']
   s.homepage    = 'https://github.com/logzio/fluent-plugin-logzio'
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'net-http-persistent', '~> 4.0'
   s.add_runtime_dependency 'fluentd', ['>= 0.14.0', '< 2']
+  s.add_runtime_dependency 'prometheus-client', '>= 2.1.0'
   s.add_development_dependency 'rake', '~> 12.3'
   s.add_development_dependency 'bundler', '~> 1.16'
   s.add_development_dependency 'rspec', '~> 3.7'

--- a/fluent-plugin-logzio.gemspec
+++ b/fluent-plugin-logzio.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = 'fluent-plugin-logzio'
-  s.version     = '0.1.0'
+  s.version     = '0.1.1'
   s.authors     = ['Yury Kotov', 'Roi Rav-Hon', 'Arcadiy Ivanov', 'Miri Bar']
   s.email       = ['bairkan@gmail.com', 'roi@logz.io', 'arcadiy@ivanov.biz', 'miri.ignatiev@logz.io']
   s.homepage    = 'https://github.com/logzio/fluent-plugin-logzio'

--- a/lib/fluent/plugin/out_logzio_buffered.rb
+++ b/lib/fluent/plugin/out_logzio_buffered.rb
@@ -139,9 +139,9 @@ module Fluent::Plugin
       end
 
       if not response.code.start_with?('2')
-        if response.code == 400
+        if response.code == '400'
           log.error "Received #{response.code} from Logzio. Some logs may be malformed or too long. Valid logs were succesfully sent into the system. Will not retry sending. Response body: #{response.body}"
-        elsif response.code == 401
+        elsif response.code == '401'
           log.error "Received #{response.code} from Logzio. Unauthorized, please check your logs shipping token. Will not retry sending. Response body: #{response.body}"
         else
           log.debug "Failed request body: #{post.body}"

--- a/lib/fluent/plugin/out_logzio_buffered.rb
+++ b/lib/fluent/plugin/out_logzio_buffered.rb
@@ -179,15 +179,15 @@ module Fluent::Plugin
       oversized_logs_counter = response_body['oversizedLines'].to_i
       new_bulk = []
       for log_record in bulk_records
-        log.debug "Oversized lines: #{oversized_logs_counter}"
-        if malformed_logs_counter == 0 && oversized_logs_counter == 0
+        log.info "Oversized lines: #{oversized_logs_counter}" # todo
+        if oversized_logs_counter == 0
           log.debug "No malformed lines, breaking"
           break
         end
-        msg_size = log_record['message'].size
+        new_log = Yajl.load(log_record)
+        msg_size = new_log['message'].size
         # Handle oversized log:
         if msg_size >= max_log_field_size_bytes
-          new_log = Yajl.load(log_record)
           new_log['message'] = new_log['message'][0,  max_log_field_size_bytes - 1]
           log.debug "new log: #{new_log}"
           new_bulk.append(Yajl.dump(new_log))

--- a/lib/fluent/plugin/out_logzio_buffered.rb
+++ b/lib/fluent/plugin/out_logzio_buffered.rb
@@ -176,19 +176,17 @@ module Fluent::Plugin
 
     def process_code_400(bulk_records, response_body)
       max_log_field_size_bytes = 32000
-      malformed_logs_counter = response_body['malformedLines'].to_i
       oversized_logs_counter = response_body['oversizedLines'].to_i
       new_bulk = []
       for log_record in bulk_records
-        log.debug "Malformed lines: #{malformed_logs_counter}"
         log.debug "Oversized lines: #{oversized_logs_counter}"
         if malformed_logs_counter == 0 && oversized_logs_counter == 0
           log.debug "No malformed lines, breaking"
           break
         end
-        log_size = log_record.size
+        msg_size = log_record['message'].size
         # Handle oversized log:
-        if log_size >= max_log_field_size_bytes
+        if msg_size >= max_log_field_size_bytes
           new_log = Yajl.load(log_record)
           new_log['message'] = new_log['message'][0,  max_log_field_size_bytes - 1]
           log.info "new log: #{new_log}" # TODO

--- a/lib/fluent/plugin/out_logzio_buffered.rb
+++ b/lib/fluent/plugin/out_logzio_buffered.rb
@@ -202,7 +202,7 @@ module Fluent::Plugin
         if response.code.start_with?('2')
           log.info "Succesfully sent bad logs"
         else
-          log.warn "While trying to send fixed bad logs, got #{response.code} from Logz.io"
+          log.warn "While trying to send fixed bad logs, got #{response.code} from Logz.io, will not try to re-send"
         end
       end
     end

--- a/lib/fluent/plugin/out_logzio_buffered.rb
+++ b/lib/fluent/plugin/out_logzio_buffered.rb
@@ -142,7 +142,7 @@ module Fluent::Plugin
 
       if not response.code.start_with?('2')
         if response.code == '400'
-          log.warn "Received #{response.code} from Logzio. Some logs may be malformed or too long. Valid logs were succesfully sent into the system. Will try to proccess and send bad logs. Response body: #{response.body}"
+          log.warn "Received #{response.code} from Logzio. Some logs may be malformed or too long. Valid logs were succesfully sent into the system. Will try to proccess and send oversized logs. Response body: #{response.body}"
           process_code_400(bulk_records, Yajl.load(response.body))
         elsif response.code == '401'
           log.error "Received #{response.code} from Logzio. Unauthorized, please check your logs shipping token. Will not retry sending. Response body: #{response.body}"
@@ -189,7 +189,7 @@ module Fluent::Plugin
         if msg_size >= max_log_field_size_bytes
           new_log = Yajl.load(log_record)
           new_log['message'] = new_log['message'][0,  max_log_field_size_bytes - 1]
-          log.info "new log: #{new_log}" # TODO
+          log.debug "new log: #{new_log}"
           new_bulk.append(Yajl.dump(new_log))
           oversized_logs_counter -= 1
         end


### PR DESCRIPTION
In this PR:
- Export metric indicating the status codes received from logz.io
- Try to handle 400 oversized logs - if received 400 from logz.io, try to detect oversized logs, and send part of them.
- Don't retry on 401.
- On any other status code that's not 2xx - retry with a nicer message.
- Update Readme.
- Bump version.